### PR TITLE
chore: Dicts functions on {{ . }}

### DIFF
--- a/cmd/templater.go
+++ b/cmd/templater.go
@@ -393,7 +393,7 @@ func (t *variants) loadFromTemplate() {
 	utils.LoadYMLFromFile(t.VariantsCfgFile, &vc)
 
 	tpl := utils.ParseTemplate(t.VariantsTplFile)
-	res := utils.ExectuteTemplate(&vc, tpl)
+	res := utils.ExectuteTemplate(vc, tpl)
 
 	utils.LoadYMLFromBytes(res, t)
 }

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -39,7 +39,7 @@ func ParseTemplate(
 
 // Executes a template with the provided data.
 func ExectuteTemplate(
-	tplData interface{},
+	tplData map[string]interface{},
 	tpl *template.Template,
 ) []byte {
 	Debug(


### PR DESCRIPTION
Closes #9 

Since the data param passed to the [template.ExecuteTemplate](https://pkg.go.dev/text/template#Template.ExecuteTemplate) function is something parsed starting from a Yaml file, we can be more specific on its type and it should be safe changing from `interface{}` to `map[string]interface{}`.

Changing the signature of `utils.ExectuteTemplate` this way, reflects in having the {{ . }} with a `map[string]interface{}` type,
so the spring's Dicts functions can be used with {{ . }} without type-checking complaints. 
